### PR TITLE
Add Staff role for bypassing kiosk restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,11 @@ All models and their relationships are listed below, alongside a brief descripti
 | Setting     | settings      | Application settings identified by a string and stored as JSON.                                                                                                                              |
 | TimeBonus   | time_bonuses  | Time periods that grant bonus volunteer time credit while being worked within. Belongs to an Event and many Departments.                                                                     |
 | TimeEntry   | time_entries  | Volunteer time clocked by users. Belongs to a User, a Department, and an Event.                                                                                                              |
-| User        | users         | Any user of the application. Has a role (Banned, Volunteer, Lead, Manager, Admin) that determines permissions.                                                                               |
+| User        | users         | Any user of the application. Has a role (Banned, Attendee, Volunteer, Staff, Lead, Manager, Admin) that determines permissions.                                                              |
 
 ### Permissions
 Permissions are implemented very simply at the moment.
-Users have a single assigned Role value, which is just an enum (Banned, Volunteer, Lead, Manager, Admin).
+Users have a single assigned Role value, which is just an enum (Banned, Attendee, Volunteer, Staff, Lead, Manager, Admin).
 - Volunteer is the default role for users. They have time tracking capabilities, but not much else.
 - Leads can authorize/deauthorize Kiosks.
 - Managers can authorize/deauthorize Kiosks, view and manage volunteers' time entries, manage attendee log attendees and gatekeepers, and create users with a badge ID.

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -6,9 +6,10 @@ use Illuminate\Support\Str;
 use Throwable;
 
 enum Role: int {
-	case Admin = 3;
-	case Manager = 2;
-	case Lead = 1;
+	case Admin = 4;
+	case Manager = 3;
+	case Lead = 2;
+	case Staff = 1;
 	case Volunteer = 0;
 	case Attendee = -1;
 	case Banned = -2;
@@ -38,9 +39,10 @@ enum Role: int {
 	 * Array of case values to descriptions for the corresponding role
 	 */
 	public const descriptions = [
-		3 => 'Administrators can do anything.',
-		2 => 'Managers can view, edit, and create time entries on behalf of other users, as well as claim rewards, create new users with a badge ID, manage attendees and gatekeepers in attendee logs, authorize kiosks, and bypass the lockdown.',
-		1 => 'Leads can authorize kiosks.',
+		4 => 'Administrators can do anything.',
+		3 => 'Managers can view, edit, and create time entries on behalf of other users, as well as claim rewards, create new users with a badge ID, manage attendees and gatekeepers in attendee logs, authorize kiosks, and bypass the lockdown.',
+		2 => 'Leads can authorize kiosks.',
+		1 => 'Staff can bypass the need for kiosks.',
 		0 => 'Volunteers can only check in and out for shifts.',
 		-1 => 'Attendees are only a placeholder for users added to attendee logs.',
 		-2 => 'Banned users can\'t do anything.',
@@ -50,9 +52,10 @@ enum Role: int {
 	 * Array of case values to action labels for the corresponding role
 	 */
 	public const actionLabels = [
-		3 => 'Make Admin',
-		2 => 'Make Manager',
-		1 => 'Make Lead',
+		4 => 'Make Admin',
+		3 => 'Make Manager',
+		2 => 'Make Lead',
+		1 => 'Make Staff',
 		0 => 'Make Volunteer',
 		-1 => 'Make Attendee',
 		-2 => 'BAN',
@@ -62,8 +65,9 @@ enum Role: int {
 	 * Array of case values to color classes for the corresponding role
 	 */
 	public const colorClasses = [
-		3 => 'danger',
-		2 => 'warning',
+		4 => 'danger',
+		3 => 'warning',
+		2 => 'success',
 		1 => 'success',
 		0 => 'info',
 		-1 => 'secondary',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -212,6 +212,15 @@ class User extends UuidModel implements AuthenticatableContract, AuthorizableCon
 	}
 
 	/**
+	 * Check whether the user should have access to staff features
+	 *
+	 * @param bool [$strict=false] Whether to check specifically for the staff role
+	 */
+	public function isStaff($strict = false): bool {
+		return $this->isRole(Role::Staff, $strict);
+	}
+
+	/**
 	 * Check whether the user has been banned
 	 */
 	public function isBanned(): bool {

--- a/app/Policies/TimeEntryPolicy.php
+++ b/app/Policies/TimeEntryPolicy.php
@@ -27,7 +27,7 @@ class TimeEntryPolicy {
 	 */
 	public function create(User $creator, User $target, ?Event $event = null): bool {
 		$validEvent = !$event || $event->isActive();
-		return ($creator->id === $target->id && $validEvent && Kiosk::isSessionAuthorized())
+		return ($creator->id === $target->id && $validEvent && (Kiosk::isSessionAuthorized() || $creator->isStaff()))
 			|| ($creator->isManager() && $validEvent)
 			|| $creator->isAdmin();
 	}
@@ -37,7 +37,7 @@ class TimeEntryPolicy {
 	 */
 	public function update(User $user, TimeEntry $timeEntry): bool {
 		$validEvent = $timeEntry->isForActiveEvent();
-		return ($user->id === $timeEntry->user_id && $validEvent && Kiosk::isSessionAuthorized())
+		return ($user->id === $timeEntry->user_id && $validEvent && (Kiosk::isSessionAuthorized() || $user->isStaff()))
 			|| ($user->isManager() && $validEvent)
 			|| $user->isAdmin();
 	}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -41,7 +41,10 @@ class AppServiceProvider extends ServiceProvider {
 		// Set up custom Blade if directives
 		Blade::if('devMode', fn () => Setting::isDevMode());
 		Blade::if('lockdown', fn () => Setting::isLockedDown());
-		Blade::if('kiosk', fn (bool $strict = false) => Kiosk::isSessionAuthorized($strict));
+		Blade::if('kiosk',
+			fn (bool $strict = false) => Kiosk::isSessionAuthorized($strict)
+				|| (!$strict && Auth::user()?->isStaff())
+		);
 		Blade::if('activeEvent', fn () => Setting::activeEvent() !== null);
 		Blade::if('admin', fn () => Auth::user()?->isAdmin() ?? false);
 		Blade::if('manager', fn () => Auth::user()?->isManager() ?? false);

--- a/database/migrations/2024_10_09_002044_adjust_user_roles_to_accommodate_staff_role.php
+++ b/database/migrations/2024_10_09_002044_adjust_user_roles_to_accommodate_staff_role.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void {
+		// Update the role of all users above volunteer
+		DB::table('users')->whereRole(3)->update(['role' => 4]);
+		DB::table('users')->whereRole(2)->update(['role' => 3]);
+		DB::table('users')->whereRole(1)->update(['role' => 2]);
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void {
+		// Update the role of staff to volunteer
+		DB::table('users')->whereRole(1)->update(['role' => 0]);
+
+		// Update the role of all users above volunteer
+		DB::table('users')->whereRole(2)->update(['role' => 1]);
+		DB::table('users')->whereRole(3)->update(['role' => 2]);
+		DB::table('users')->whereRole(4)->update(['role' => 3]);
+	}
+};

--- a/resources/js/lib/user.js
+++ b/resources/js/lib/user.js
@@ -19,9 +19,10 @@ export function useUser() {
 		isLoggedIn: toRef(() => Boolean(page.props.auth.user)),
 		isGatekeeper: toRef(() => page.props.isGatekeeper),
 		isBanned: toRef(() => page.props.auth.user?.role === -2),
-		isLead: toRef(() => page.props.auth.user?.role >= 1),
-		isManager: toRef(() => page.props.auth.user?.role >= 2),
-		isAdmin: toRef(() => page.props.auth.user?.role === 3),
+		isStaff: toRef(() => page.props.auth.user?.role >= 1),
+		isLead: toRef(() => page.props.auth.user?.role >= 2),
+		isManager: toRef(() => page.props.auth.user?.role >= 3),
+		isAdmin: toRef(() => page.props.auth.user?.role === 4),
 	};
 }
 
@@ -29,9 +30,10 @@ export function useUser() {
  * Role names mapped by their numeric ID
  */
 export const roleNames = {
-	3: 'Admin',
-	2: 'Manager',
-	1: 'Lead',
+	4: 'Admin',
+	3: 'Manager',
+	2: 'Lead',
+	1: 'Staff',
 	0: 'Volunteer',
 	'-1': 'Attendee',
 	'-2': 'Banned',


### PR DESCRIPTION
Adds a new Staff role that allows users to bypass kiosk requirements.
The user role management UI really needs to be reworked with this one, given the likely quantity of users that will be in the list, but that's a later task!

Closes #17.