### PR TITLE
Fix volunteer selection auto-scroll on manager dashboard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,7 @@ jobs:
   merge:
     name: "Merge: ${{ matrix.image.name }}"
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     needs:
       - build
     strategy:

--- a/resources/js/Components/Volunteer/VolunteerManagePanel.vue
+++ b/resources/js/Components/Volunteer/VolunteerManagePanel.vue
@@ -73,23 +73,22 @@ function attention() {
 	// @ts-expect-error
 	const el = panel.value!.$el;
 
-	// Pulse the panel border
 	setTimeout(() => {
+		// Pulse the panel border
 		el.classList.add('border-primary');
-
 		if (attnTimeout) clearTimeout(attnTimeout);
-
 		attnTimeout = setTimeout(() => {
 			el.classList.remove('border-primary');
 			attnTimeout = null;
 		}, 500);
-	}, 0);
 
-	// Scroll to the panel if the header isn't in view
-	if (!isElementInView(closeBtn.value!.$el)) {
-		el.scrollIntoView({
-			block: el.clientHeight < window.innerHeight ? 'center' : 'start',
-		});
-	}
+		// Scroll to the panel if the header isn't in view
+		if (!isElementInView(closeBtn.value!.$el)) {
+			el.scrollIntoView({
+				block: el.clientHeight < window.innerHeight ? 'center' : 'start',
+				container: 'nearest',
+			});
+		}
+	}, 0);
 }
 </script>


### PR DESCRIPTION
Fixes the auto-scrolling behaviour when selecting a volunteer on the manager dashboard. As of a Vue update, it hasn't been auto-scrolling to the volunteer details panel due to a timing issue. Moving the logic into a timeout ensures execution happens only after the DOM has been modified and the browser has repainted. `nextTick()` would also likely work fine here, but that's inherently higher-priority than `setTimeout()` since it'd use a microtask instead of a macrotask, which is unnecessary for this purpose.