### PR TITLE
Skip merge job on pull requests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,7 @@ jobs:
   merge:
     name: "Merge: ${{ matrix.image.name }}"
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     needs:
       - build
     strategy:


### PR DESCRIPTION
   - Adds `if: github.event_name != 'pull_request'` condition to the `merge` job in `publish.yml`
   - The `build` job already skips uploading digests on PRs; without this fix, the `merge` job would still run but fail because no digest artifacts exist