### PR TITLE
Show only the event's own departments in the department summary report

### DIFF
--- a/app/Reports/DepartmentSummaryReport.php
+++ b/app/Reports/DepartmentSummaryReport.php
@@ -23,11 +23,9 @@ class DepartmentSummaryReport extends EventReport implements FromQuery, ShouldAu
 	use FormatsAsTable, RegistersEventListeners;
 
 	public function query(): Builder {
-		return Department::with([
-			'timeEntries' => function ($query) {
-				$query->forEvent($this->event);
-			},
-		])->orderBy('name');
+		return Department::with('timeEntries')
+			->forEvent($this->event)
+			->orderBy('name');
 	}
 
 	/** @param Department $department */


### PR DESCRIPTION
This fixes the behavior of the department summary report to only show departments for the selected event since departments were made event-specific.