### PR TITLE
Fix horizontal & vertical scrolling of DataTables within panels

### DIFF
--- a/resources/js/Components/Common/FullContentHeightPanel.vue
+++ b/resources/js/Components/Common/FullContentHeightPanel.vue
@@ -2,7 +2,8 @@
 	<Panel
 		class="flex flex-col"
 		:pt="{
-			contentContainer: { class: 'grow' },
+			contentContainer: { class: 'grow min-h-0' },
+			contentWrapper: { class: 'min-w-0' },
 			content: { class: 'h-full p-0' },
 			...pt,
 		}"

--- a/resources/js/Components/Volunteer/VolunteerManagePanel.vue
+++ b/resources/js/Components/Volunteer/VolunteerManagePanel.vue
@@ -5,6 +5,7 @@
 		class="transition-colors duration-400"
 		:pt="{
 			header: { class: 'items-start' },
+			contentWrapper: { class: 'min-w-0' },
 		}"
 	>
 		<template #header>

--- a/resources/js/Components/Volunteer/VolunteerTimeEntriesPanel.vue
+++ b/resources/js/Components/Volunteer/VolunteerTimeEntriesPanel.vue
@@ -1,5 +1,5 @@
 <template>
-	<Panel header="Shift Log">
+	<Panel header="Shift Log" :pt="{ contentWrapper: { class: 'min-w-0' } }">
 		<DataTable
 			:value="values"
 			data-key="id"

--- a/resources/js/Layouts/NavLayout.vue
+++ b/resources/js/Layouts/NavLayout.vue
@@ -5,7 +5,7 @@
 		<div class="grow lg:overflow-auto flex flex-col" scroll-region>
 			<DevBadges v-if="isDevMode" class="mx-2 mb-4 lg:mb-0 lg:mt-4" />
 
-			<main class="grow p-4 pt-0 lg:ps-0 lg:pt-4 flex flex-col"><slot /></main>
+			<main class="grow p-4 pt-0 lg:ps-0 lg:pt-4 flex flex-col min-h-0"><slot /></main>
 		</div>
 	</div>
 </template>

--- a/resources/js/Pages/Users.vue
+++ b/resources/js/Pages/Users.vue
@@ -1,6 +1,6 @@
 <template>
-	<div class="grow flex flex-col gap-4">
-		<FullContentHeightPanel header="Users" class="grow">
+	<div class="grow flex flex-col gap-4 min-h-0">
+		<FullContentHeightPanel header="Users" class="grow min-h-0">
 			<UsersTable
 				:users
 				:total-records="total"


### PR DESCRIPTION
This resolves the issues with DataTables contained within Panels (which is every DataTable):
- Overflowing outside of their container's width rather than horizontally scrolling
- Always preferring to stretch or overflow their parent's height rather than vertically scrolling regardless of scrollable setting & parent container size