### PR TITLE
Add NFC badge tap-in support

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Events\QuickCodeLogin;
+use App\Http\Requests\NfcLoginRequest;
 use App\Http\Requests\QuickCodeRequest;
 use App\Models\Kiosk;
 use App\Models\QuickCode;
@@ -106,6 +107,45 @@ class AuthController extends Controller {
 		QuickCodeLogin::dispatch($quickcode);
 		Auth::login($quickcode->user);
 		$quickcode->delete();
+
+		return $request->expectsJson()
+			? response()->json(null, 205)
+			: redirect()->route('volunteer.index');
+	}
+
+	/**
+	 * Logs the user in via an NFC badge tap, relayed from a workstation-local ConcatNFCValidator instance. Only usable
+	 * from sessions already authorized as a Kiosk - trusting a client-submitted attendeeId for login is only
+	 * reasonable in that physically-trusted context.
+	 */
+	public function postNfc(NfcLoginRequest $request): JsonResponse|RedirectResponse {
+		if (!Kiosk::isSessionAuthorized(true)) {
+			$error = 'NFC login is only available on authorized kiosks.';
+			return $request->expectsJson()
+				? response()->json(['error' => $error], 403)
+				: redirect()->back()->withErrors(['attendeeId' => $error]);
+		}
+
+		// Prevent too many rapid failed attempts
+		$rateLimitKey = "nfc:{$request->ip()}";
+		if (RateLimiter::tooManyAttempts($rateLimitKey, $perMinute = 5)) {
+			$error = 'Too many failed NFC login attempts have been made from this location. Try again in a minute.';
+			return $request->expectsJson()
+				? response()->json(['error' => $error], 429)
+				: redirect()->back()->withErrors(['attendeeId' => $error]);
+		}
+
+		$user = User::whereBadgeId($request->attendeeId)->first();
+
+		if (!$user) {
+			RateLimiter::hit($rateLimitKey);
+			$error = 'No Tracker account is linked to this badge.';
+			return $request->expectsJson()
+				? response()->json(['errors' => $error], 401)
+				: redirect()->back()->withErrors(['attendeeId' => $error]);
+		}
+
+		Auth::login($user);
 
 		return $request->expectsJson()
 			? response()->json(null, 205)

--- a/app/Http/Requests/NfcLoginRequest.php
+++ b/app/Http/Requests/NfcLoginRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class NfcLoginRequest extends FormRequest {
+	/**
+	 * Determine if the user is authorized to make this request.
+	 */
+	public function authorize(): bool {
+		return true;
+	}
+
+	/**
+	 * Get the validation rules that apply to the request.
+	 *
+	 * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+	 */
+	public function rules(): array {
+		return [
+			'attendeeId' => 'required|integer',
+		];
+	}
+}

--- a/resources/js/Components/AttendeeLog/AttendeeCreatePanel.vue
+++ b/resources/js/Components/AttendeeLog/AttendeeCreatePanel.vue
@@ -14,6 +14,7 @@
 					Return &#9166;
 				</kbd>
 				key press after the badge number.
+				<template v-if="nfcReady">NFC badge taps on a workstation-local reader are submitted the same way.</template>
 			</p>
 
 			<form @submit.prevent="create" @input="form.clearErrors()">
@@ -55,9 +56,10 @@
 </template>
 
 <script setup lang="ts">
-import { useId, useTemplateRef } from 'vue';
+import { useId, useTemplateRef, onMounted, onUnmounted, computed } from 'vue';
 import { useForm } from '@inertiajs/vue3';
 import { useRoute } from '@/lib/route';
+import { useNfcTap, type NfcTap } from '@/lib/nfcTap';
 import type AttendeeLog from '@/data/AttendeeLog';
 
 import { faUserPlus } from '@fortawesome/free-solid-svg-icons';
@@ -111,4 +113,17 @@ function create() {
 		},
 	});
 }
+
+// Submits like a badge scanner's Return keypress would, for stations with an NFC reader attached. Silent/
+// best-effort - if no workstation-local ConcatNFCValidator is reachable this just quietly never fires. Not wired up
+// for "Empower Gatekeeper" - that shouldn't happen from a stray tap with no separate confirmation.
+const { stage: nfcStage, start: startNfcTap, stop: stopNfcTap } = useNfcTap((tap: NfcTap) => {
+	form.badge_id = String(tap.attendeeId);
+	create();
+});
+const nfcReady = computed(() => nfcStage.value !== 'idle' && nfcStage.value !== 'searching');
+onMounted(() => {
+	if (!gatekeeper) startNfcTap();
+});
+onUnmounted(() => stopNfcTap());
 </script>

--- a/resources/js/Components/User/UsersTable.vue
+++ b/resources/js/Components/User/UsersTable.vue
@@ -80,12 +80,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, ref, watch, onMounted, onUnmounted } from 'vue';
 import vueDebounce from 'vue-debounce';
 import { FilterMatchMode } from '@primevue/core/api';
 import type { DataTableFilterEvent, DataTablePageEvent, DataTableSortEvent } from 'primevue/datatable';
 
 import { useInertiaRequest } from '@/lib/request';
+import { useNfcTap, type NfcTap } from '@/lib/nfcTap';
 import { roleNames, useUser } from '@/lib/user';
 import User from '@/data/impl/User';
 import type RawUser from '@/data/User';
@@ -168,4 +169,13 @@ async function loadPage(evt: DataTablePageEvent | DataTableSortEvent | DataTable
 		role: filters.value.role.value ?? undefined,
 	});
 }
+
+// Autofill the ID filter with a tapped badge's ID, for lookups on a workstation with an NFC reader attached.
+// Silent/best-effort - if no workstation-local ConcatNFCValidator is reachable this just quietly never fires.
+const { start: startNfcTap, stop: stopNfcTap } = useNfcTap((tap: NfcTap) => {
+	filters.value.badge_id.value = tap.attendeeId;
+	return request.get('users.index', { badge_id: tap.attendeeId });
+});
+onMounted(() => startNfcTap());
+onUnmounted(() => stopNfcTap());
 </script>

--- a/resources/js/Components/Volunteer/VolunteerSearchTable.vue
+++ b/resources/js/Components/Volunteer/VolunteerSearchTable.vue
@@ -87,9 +87,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted, onUnmounted } from 'vue';
 import vueDebounce from 'vue-debounce';
 import { useRequest } from '@/lib/request';
+import { useNfcTap, type NfcTap } from '@/lib/nfcTap';
 import User from '@/data/impl/User';
 import type RawUser from '@/data/User';
 import type { UserId } from '@/data/User';
@@ -140,4 +141,13 @@ async function searchUsers() {
 function getDepartment(user: User): Department | undefined {
 	return user.time_entries?.[0]?.department;
 }
+
+// Autofill the search field with a tapped badge's ID, for lookups on a workstation with an NFC reader attached.
+// Silent/best-effort - if no workstation-local ConcatNFCValidator is reachable this just quietly never fires.
+const { start: startNfcTap, stop: stopNfcTap } = useNfcTap((tap: NfcTap) => {
+	query.value = String(tap.attendeeId);
+	return searchUsers();
+});
+onMounted(() => startNfcTap());
+onUnmounted(() => stopNfcTap());
 </script>

--- a/resources/js/Pages/Login.vue
+++ b/resources/js/Pages/Login.vue
@@ -58,13 +58,29 @@
 					</Button>
 				</form>
 			</Panel>
+
+			<Panel v-if="isKiosk && nfcReady" class="mt-4">
+				<template #header><h2 class="grow ms-4 text-center text-xl font-thin">Badge Tap-In</h2></template>
+
+				<Message :severity="nfcMessageSeverity" :pt="{ content: { class: 'flex min-h-12 items-center justify-center gap-2' } }">
+					<FontAwesomeIcon v-if="nfcStage === 'processing'" :icon="faSpinner" spin />
+					<FontAwesomeIcon v-else-if="nfcStage === 'waiting'" :icon="faIdCardClip" />
+					<FontAwesomeIcon v-else :icon="faTriangleExclamation" />
+					<span>{{ nfcStatusText }}</span>
+				</Message>
+			</Panel>
 		</Panel>
 	</div>
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted, onUnmounted } from 'vue';
 import { useForm } from '@inertiajs/vue3';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { faIdCardClip, faSpinner, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { useRoute } from '@/lib/route';
+import { useAppSettings } from '@/lib/settings';
+import { useNfcLogin } from '@/lib/nfcLogin';
 
 import BaseLayout from '@/Layouts/BaseLayout.vue';
 import NavlessLayout from '@/Layouts/NavlessLayout.vue';
@@ -82,4 +98,31 @@ const qcForm = useForm({ code: '' });
 function submitQuickCode() {
 	qcForm.post(route('auth.quickcode.post'), { replace: true });
 }
+
+const { isKiosk } = useAppSettings();
+const { stage: nfcStage, error: nfcError, start: startNfcLogin, stop: stopNfcLogin } = useNfcLogin();
+
+// Only show the panel once the validator has actually answered a health check - no point showing a "sign in
+// with your badge" option that's silently unusable because no reader is plugged in/running on this kiosk.
+const nfcReady = computed(() => nfcStage.value !== 'idle' && nfcStage.value !== 'searching');
+
+const nfcStatusText = computed(() => {
+	switch (nfcStage.value) {
+		case 'waiting':
+			return 'Tap your badge on the reader to sign in.';
+		case 'processing':
+			return 'Badge read, signing you in...';
+		case 'error':
+			return nfcError.value ?? 'NFC login failed.';
+		default:
+			return '';
+	}
+});
+
+const nfcMessageSeverity = computed(() => (nfcStage.value === 'error' ? 'error' : 'secondary'));
+
+onMounted(() => {
+	if (isKiosk.value) startNfcLogin();
+});
+onUnmounted(() => stopNfcLogin());
 </script>

--- a/resources/js/lib/nfcLogin.ts
+++ b/resources/js/lib/nfcLogin.ts
@@ -1,0 +1,27 @@
+import { useInertiaRequest } from './request';
+import { useNfcTap, type NfcTap } from './nfcTap';
+
+/**
+ * Logs in the Tracker user matching a badge tapped on a workstation-local ConcatNFCValidator instance. Only meaningful on
+ * sessions authorized as a Kiosk (callers should gate on that separately - this composable has no opinion on it
+ * beyond that the backend login endpoint enforces it too).
+ */
+export function useNfcLogin() {
+	const inertiaRequest = useInertiaRequest();
+
+	return useNfcTap(
+		(tap: NfcTap) =>
+			new Promise<void>((resolve, reject) => {
+				inertiaRequest.post(
+					'auth.nfc.post',
+					{ attendeeId: tap.attendeeId },
+					{
+						onSuccess: () => resolve(),
+						onError(errors) {
+							reject(new Error(errors.attendeeId ?? Object.values(errors)[0] ?? 'NFC login failed.'));
+						},
+					},
+				);
+			}),
+	);
+}

--- a/resources/js/lib/nfcTap.ts
+++ b/resources/js/lib/nfcTap.ts
@@ -1,0 +1,146 @@
+import { ref } from 'vue';
+
+const VALIDATOR_BASE_URL = 'http://localhost:7071';
+
+const HEALTH_POLL_MS = 5000;
+const STATUS_POLL_MS = 1500;
+
+export type NfcTapStage = 'idle' | 'searching' | 'waiting' | 'processing' | 'error';
+
+export interface NfcTap {
+	uid: string;
+	attendeeId: number;
+	conventionId?: number;
+	scannedAt?: string;
+}
+
+interface HealthResponse {
+	alive: boolean;
+	readerReady: boolean;
+}
+
+interface StatusResponse {
+	valid: boolean;
+	uid?: string;
+	attendeeId?: number;
+	conventionId?: number;
+	scannedAt?: string;
+}
+
+/**
+ * Polls a workstation-local ConcatNFCValidator instance for a validated badge tap and invokes onTap for
+ * each one. onTap is awaited - the stage is 'processing' while it's pending, and if it throws, the stage becomes
+ * 'error' with the message exposed via `error` until the next tap comes in. The scan is acknowledged (so the
+ * validator clears it and accepts the next one) regardless of whether onTap succeeds.
+ */
+export function useNfcTap(onTap: (tap: NfcTap) => void | Promise<void>) {
+	const stage = ref<NfcTapStage>('idle');
+	const error = ref<string | null>(null);
+
+	let generation = 0;
+
+	/**
+	 * Begins polling the validator. Safe to call again to restart after stop().
+	 */
+	function start() {
+		if (stage.value !== 'idle' && stage.value !== 'error') return;
+		error.value = null;
+		stage.value = 'searching';
+		const myGeneration = ++generation;
+		void pollHealth(myGeneration);
+	}
+
+	/**
+	 * Stops polling. Any in-flight request's result will be ignored once it resolves.
+	 */
+	function stop() {
+		generation++;
+		stage.value = 'idle';
+	}
+
+	/**
+	 * Polls /health until the validator answers, then switches to polling /status
+	 */
+	async function pollHealth(myGeneration: number) {
+		if (myGeneration !== generation) return;
+
+		try {
+			const res = await fetch(`${VALIDATOR_BASE_URL}/health`, { signal: AbortSignal.timeout(3000) });
+			if (!res.ok) throw new Error(`Unexpected status ${res.status}`);
+			await (res.json() as Promise<HealthResponse>);
+
+			if (myGeneration !== generation) return;
+			stage.value = 'waiting';
+			void pollStatus(myGeneration);
+			return;
+		} catch {
+			// Validator not reachable - fall through to marking it as searching and retrying below
+		}
+
+		if (myGeneration !== generation) return;
+		stage.value = 'searching';
+		setTimeout(() => void pollHealth(myGeneration), HEALTH_POLL_MS);
+	}
+
+	/**
+	 * Polls /status for a validated badge tap. Falls back to pollHealth if the validator stops responding.
+	 */
+	async function pollStatus(myGeneration: number) {
+		if (myGeneration !== generation) return;
+
+		let status: StatusResponse;
+		try {
+			const res = await fetch(`${VALIDATOR_BASE_URL}/status`, { signal: AbortSignal.timeout(3000) });
+			if (!res.ok) throw new Error(`Unexpected status ${res.status}`);
+			status = await res.json();
+		} catch {
+			if (myGeneration !== generation) return;
+			// A single missed poll doesn't necessarily mean the validator is down - recheck health right away
+			// instead of dropping to 'searching' (and hiding the tap-in UI) over one transient blip.
+			void pollHealth(myGeneration);
+			return;
+		}
+
+		if (myGeneration !== generation) return;
+
+		if (!status.valid || status.attendeeId == null || !status.uid) {
+			setTimeout(() => void pollStatus(myGeneration), STATUS_POLL_MS);
+			return;
+		}
+
+		const tap: NfcTap = {
+			uid: status.uid,
+			attendeeId: status.attendeeId,
+			conventionId: status.conventionId,
+			scannedAt: status.scannedAt,
+		};
+
+		error.value = null;
+		stage.value = 'processing';
+
+		// Acknowledge the scan so the validator can clear it and accept the next one, regardless of whether
+		// onTap below succeeds.
+		fetch(`${VALIDATOR_BASE_URL}/ack`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ uid: tap.uid }),
+		}).catch(() => {
+			// Non-fatal - the validator will expire the pending scan on its own after a while
+		});
+
+		try {
+			await onTap(tap);
+			if (myGeneration !== generation) return;
+			stage.value = 'waiting';
+		} catch (err) {
+			if (myGeneration !== generation) return;
+			error.value = err instanceof Error ? err.message : 'Failed to handle badge tap.';
+			stage.value = 'error';
+		}
+
+		if (myGeneration !== generation) return;
+		setTimeout(() => void pollStatus(myGeneration), STATUS_POLL_MS);
+	}
+
+	return { stage, error, start, stop };
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ Route::controller(\App\Http\Controllers\AuthController::class)->group(function (
 	Route::get('/auth/redirect', 'getRedirect')->name('auth.redirect');
 	Route::get('/auth/callback', 'getCallback')->name('auth.callback');
 	Route::post('/auth/quickcode', 'postQuickcode')->name('auth.quickcode.post');
+	Route::post('/auth/nfc', 'postNfc')->name('auth.nfc.post');
 	Route::get('/disabled/account', 'getBanned')->name('auth.banned');
 });
 


### PR DESCRIPTION
An NFC badge reader plugged into a system running ConcatNFCValidator lets Tracker poll that instance via nfcTap.ts for badge scans, used across several areas:

- Kiosk login: sign in via badge tap through a new /auth/nfc endpoint, gated server-side by Kiosk::isSessionAuthorized()
- Manager Dashboard: autofill volunteer search from a badge tap
- Users page: autofill the ID filter from a badge tap
- Attendee log: submit log entries directly from a badge tap